### PR TITLE
Fix canonicalize

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1853,7 +1853,7 @@ dependencies = [
 
 [[package]]
 name = "teemiao"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "teemiao"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 description = "Teemiao is a versatile toolkit designed to streamline application development workflows."
 license = "Apache-2.0"

--- a/src/build_info/mod.rs
+++ b/src/build_info/mod.rs
@@ -91,7 +91,7 @@ impl BuildInfoCommand {
             path.push("build_info.json");
             path
         });
-        let out = absolute(out)?.canonicalize()?;
+        let out = absolute(out)?;
         debug!("Output file: {}", &out.display());
 
         trace!("Opening {} as git repository...", &cwd.display());


### PR DESCRIPTION
Fixed a bug where we are calling canonicalize on output path for
no reason.

The function canonicalize requires the output file to exist to
begin with, and this is not always the case since we might generate
the file for the first time.